### PR TITLE
修复当LDAP管理员密码中存在双引号时的bug

### DIFF
--- a/vCenterLDAP_Manage.py
+++ b/vCenterLDAP_Manage.py
@@ -21,7 +21,7 @@ def GetLDAPConfig():
     dcAccountDN = result[index2:].split('\n')[0].split('"')[2]
     
     index3 = result.find("dcAccountPassword")
-    dcAccountPassword = result[index3:].split('\n')[0].split('"')[2]
+    dcAccountPassword = result[index3:].split('\n')[0].split()[2][1:-1].replace('\\"', '"')
     
     print("[+] dcAccount: " + dcAccount)
     print("[+] dcAccountDN: " + dcAccountDN)
@@ -63,7 +63,7 @@ userPassword: P@ssWord123@@
     fo.close()
 
     print("[*] Try to add the data")
-    command = "ldapadd -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" -f adduser.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
+    command = "ldapadd -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' -f adduser.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
     print("[+] Command: " + command)
     result = RunCommand(command)
     print(result)
@@ -102,7 +102,7 @@ member: {dn}
     fo.close()
 
     print("[*] Try to modify the data")
-    command = "ldapmodify -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" -f addadmin.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
+    command = "ldapmodify -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' -f addadmin.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
     print("[+] Command: " + command)
     result = RunCommand(command)
     print(result)
@@ -139,7 +139,7 @@ userPassword: {newpassword}
     fo.close()
 
     print("[*] Try to modify the data")
-    command = "ldapmodify -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" -f changepass.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
+    command = "ldapmodify -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' -f changepass.ldif".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword)
     print("[+] Command: " + command)
     result = RunCommand(command)
     print(result)
@@ -160,7 +160,7 @@ def DeleteUser():
     dn = input("input the user dn: ")
 
     print("[*] Try to delete the data")
-    command = "ldapdelete -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" \"{dn}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, dn = dn)
+    command = "ldapdelete -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' \"{dn}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, dn = dn)
     print("[+] Command: " + command)
     result = RunCommand(command)
     print(result)
@@ -174,7 +174,7 @@ def GetAdmin():
     adminbase = "cn=Administrators,cn=Builtin," + base
 
     print("[*] Try to get the data")
-    command = "ldapsearch -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" -b \"{adminbase}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, adminbase = adminbase)
+    command = "ldapsearch -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' -b \"{adminbase}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, adminbase = adminbase)
     print("[+] Command: " + command)
     result = RunCommand(command)
     print("[+] Admin User:")
@@ -193,7 +193,7 @@ def GetUser():
     adminbase = "cn=Users," + base
 
     print("[*] Try to get the data")
-    command = "ldapsearch -x -h {dcAccount} -D \"{dcAccountDN}\" -w \"{dcAccountPassword}\" -b \"{adminbase}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, adminbase = adminbase)
+    command = "ldapsearch -x -h {dcAccount} -D \"{dcAccountDN}\" -w '{dcAccountPassword}' -b \"{adminbase}\"".format(dcAccount = dcAccount, dcAccountDN = dcAccountDN, dcAccountPassword = dcAccountPassword, adminbase = adminbase)
     print("[+] Command: " + command)
     result = RunCommand(command)
 


### PR DESCRIPTION
LDAP管理员随机密码中存在引号时，会导致获取的密码被截断，获取不全
![image](https://user-images.githubusercontent.com/21152875/176656496-659f83ec-5eca-4544-bb74-22ee1fedde23.png)


![image](https://user-images.githubusercontent.com/21152875/176655640-aa922aae-09c2-4790-a288-1bc056479270.png)

由于密码中存在双引号，还会影响 ldap 命令
![image](https://user-images.githubusercontent.com/21152875/176656017-df4d438c-7e1e-4f58-b14d-1612be47f133.png)

